### PR TITLE
Add dependency scanning and update security docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/client"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/dependency_audit.yml
+++ b/.github/workflows/dependency_audit.yml
@@ -1,0 +1,32 @@
+name: Dependency Audit
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  npm-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci --workspaces
+      - name: Audit root
+        run: npm audit --production
+      - name: Audit backend
+        run: npm audit --prefix backend --production
+      - name: Audit client
+        run: npm audit --prefix client --production
+      - name: Generate SBOM
+        run: npm run generate:sbom
+      - name: Upload SBOM
+        uses: actions/upload-artifact@v3
+        with:
+          name: sbom
+          path: sbom.json

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ backend/.env
 backup.sql
 nom-de-domaine.txt
 backend/logs/
+sbom.json

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ This project provides a training platform composed of a React frontend and an Ex
 Environment variables are loaded from a `.env` file (see `.env.example`).
 Run `docker-compose -f docker-compose.dev.yml up` for a development setup.
 
+## Dependency updates
+
+Security updates are tracked automatically with GitHub Dependabot. Every pull
+request runs an `npm audit` job to detect vulnerable packages. A Software Bill
+of Materials can be generated with `npm run generate:sbom`.
+
 ## Security documentation
 
 Security related design notes and a simple STRIDE threat model are available in the [docs](docs/) folder:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,7 +2,7 @@
 # CAF-Trainer • backend • Dockerfile (production)
 ############################################################
 # ── Étape 1 : build ───────────────────────────────────────
-FROM node:20-alpine AS build
+FROM node:20.11-alpine AS build
 WORKDIR /app
 ENV NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/corp-root-ca.crt
 
@@ -24,7 +24,7 @@ RUN npx prisma generate
 RUN npm run build                          
 
 # ── Étape 2 : runtime léger ────────────────
-FROM node:20-alpine
+FROM node:20.11-alpine
 WORKDIR /app/backend
 ENV NODE_ENV=production \
     NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/corp-root-ca.crt

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,7 +1,7 @@
 ############################################################
 # CAF-Trainer • backend • Dockerfile.dev (hot-reload)
 ############################################################
-FROM node:20-alpine
+FROM node:20.11-alpine
 WORKDIR /app
 ENV NODE_ENV=development \
     NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/corp-root-ca.crt

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -2,7 +2,7 @@
 # CAF-Trainer • client • Dockerfile (production)
 ############################################################
 ### Étape 1 : build CRA ####################################
-FROM node:20-alpine AS build
+FROM node:20.11-alpine AS build
 WORKDIR /app
 ENV NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/corp-root-ca.crt
 
@@ -17,7 +17,7 @@ COPY client ./client
 WORKDIR /app/client
 RUN npm run build                   
 ### Étape 2 : image Nginx ##################################
-FROM nginx:1.25-alpine
+FROM nginx:1.25.2-alpine
 WORKDIR /usr/share/nginx/html
 RUN addgroup -g 1001 app && adduser -D -G app -u 1001 app
 

--- a/client/Dockerfile.dev
+++ b/client/Dockerfile.dev
@@ -1,7 +1,7 @@
 ############################################################
 # CAF-Trainer • client • Dockerfile.dev (CRA + hot-reload)
 ############################################################
-FROM node:20-alpine
+FROM node:20.11-alpine
 WORKDIR /app
 ENV NODE_ENV=development \
     CHOKIDAR_USEPOLLING=true \

--- a/docs/SECURITY_DESIGN.md
+++ b/docs/SECURITY_DESIGN.md
@@ -16,6 +16,16 @@ Secrets are loaded from environment variables using `dotenv` and validated on st
 - **Logging and Audit**: a winston based logger records HTTP requests and errors to a log file.
 - **Revocation**: JWT tokens include a `tokenVersion` checked against the database to allow revocation.
 
+## Dependency Management
+
+The project relies on third‑party packages that must be kept up to date to
+avoid known vulnerabilities. Updates are tracked automatically by GitHub
+Dependabot for all workspaces and GitHub Actions. Every pull request triggers a
+`npm audit` workflow which fails the build if high or critical issues are
+reported. A Software Bill of Materials (SBOM) can be generated with
+`npm run generate:sbom` to inventory components. Dependencies should be reviewed
+weekly and updated promptly when security patches are released.
+
 ## Validation
 
 This document is intended for peer or security expert review to validate the overall design and proposed protections.

--- a/package.json
+++ b/package.json
@@ -1,25 +1,26 @@
 {
-    "name": "caf-trainer-ts",
-    "version": "1.0.0",
-    "private": true,
-    "workspaces": [
+  "name": "caf-trainer-ts",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": [
     "backend",
     "client"
-    ],
-    "scripts": {
+  ],
+  "scripts": {
     "start:backend": "npm --workspace backend start",
     "start:client": "npm --workspace client start",
-    "start": "concurrently \"npm run start:backend\" \"npm run start:client\""
-    },
-    "devDependencies": {
+    "start": "concurrently \"npm run start:backend\" \"npm run start:client\"",
+    "generate:sbom": "npx cyclonedx-bom -o sbom.json"
+  },
+  "devDependencies": {
     "@types/nodemailer": "^6.4.17",
     "@types/react": "^18.3.21",
     "@types/react-dom": "^18.3.7",
     "concurrently": "^9.1.2",
     "vite": "^6.3.5"
-    },
-    "dependencies": {
+  },
+  "dependencies": {
     "quill": "^2.0.3",
     "react-quill": "^2.0.0"
-    }
-    }
+  }
+}


### PR DESCRIPTION
## Summary
- configure Dependabot for weekly updates
- add workflow to run npm audit and produce an SBOM
- document update process and SBOM generation
- ignore generated sbom.json file
- pin Docker images to specific patch versions

## Testing
- `npm test --workspaces` *(fails: Missing script `test`)*